### PR TITLE
Properly parse globs that contain empty alternate patterns

### DIFF
--- a/lib/refinement/changeset.rb
+++ b/lib/refinement/changeset.rb
@@ -89,7 +89,7 @@ module Refinement
       pattern = pattern.gsub('/**/', '{/**/,/}')
       values_by_set = {}
       pattern.scan(/\{[^}]*\}/) do |set|
-        values = set.gsub(/[{}]/, '').split(',')
+        values = set.gsub(/[{}]/, '').split(',', -1)
         values_by_set[set] = values
       end
 

--- a/spec/refinement/used_path_spec.rb
+++ b/spec/refinement/used_path_spec.rb
@@ -30,6 +30,22 @@ RSpec.describe Refinement::UsedPath do
         expect(change_reason).to eq 'main.swift (super important file) was changed'
       end
     end
+
+    context 'with the path pointing to a hidden file' do
+      let(:path) { Pathname('/repo/.rc') }
+
+      context 'when the changeset contains the path' do
+        let(:changeset) do
+          Refinement::Changeset.new(repository: Pathname('/repo'), modifications: [
+                                      Refinement::Changeset::FileModification.new(path: Pathname('.rc'), type: :'was changed')
+                                    ])
+        end
+
+        it 'returns the change reason' do
+          expect(change_reason).to eq '.rc (super important file) was changed'
+        end
+      end
+    end
   end
 
   describe '#to_s' do
@@ -106,6 +122,34 @@ RSpec.describe Refinement::UsedPath do
 
         it 'returns the change reason' do
           expect(change_reason).to eq 'main.swift (super important file) was changed'
+        end
+      end
+
+      context 'with a glob pointing to a hidden file' do
+        let(:glob) { '/repo/{*,}.rc' }
+
+        context 'when the changeset contains the path' do
+          let(:changeset) do
+            Refinement::Changeset.new(repository: Pathname('/repo'), modifications: [
+                                        Refinement::Changeset::FileModification.new(path: Pathname('.rc'), type: :'was changed')
+                                      ])
+          end
+
+          it 'returns the change reason' do
+            expect(change_reason).to eq '.rc (super important file) was changed'
+          end
+        end
+
+        context 'when the changeset contains the non-invisible path' do
+          let(:changeset) do
+            Refinement::Changeset.new(repository: Pathname('/repo'), modifications: [
+                                        Refinement::Changeset::FileModification.new(path: Pathname('foo.rc'), type: :'was changed')
+                                      ])
+          end
+
+          it 'returns the change reason' do
+            expect(change_reason).to eq 'foo.rc (super important file) was changed'
+          end
         end
       end
     end


### PR DESCRIPTION
eg. {foo,} => ["foo", ""] as opposed to simply "foo"